### PR TITLE
ENH compute a WM mask for normalization

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -58,6 +58,8 @@ OPTIONAL ARGUMENTS (current value)
 
 --bet_dwi_final_f                           Fractional Intensity threshold for the final DWI BET ($bet_dwi_final_f).
 
+--fa_mask_threshold                         FA threshold to compute WM mask for normalization ($fa_mask_threshold).
+
 --run_resample_dwi                          Run resample DWI ($run_resample_dwi).
 --dwi_resolution                            DWI resolution ($dwi_resolution).
 --dwi_interpolation                         Interpolation method [nn, lin, quad, cubic] ($dwi_interpolation).

--- a/main.nf
+++ b/main.nf
@@ -23,6 +23,7 @@ if(params.help) {
                 "bet_topup_before_eddy_f":"$params.bet_topup_before_eddy_f",
                 "use_slice_drop_correction":"$params.use_slice_drop_correction",
                 "bet_dwi_final_f":"$params.bet_dwi_final_f",
+                "fa_mask_threshold":"$params.fa_mask_threshold",
                 "run_resample_dwi":"$params.run_resample_dwi",
                 "dwi_resolution":"$params.dwi_resolution",
                 "dwi_interpolation":"$params.dwi_interpolation",
@@ -635,7 +636,7 @@ process Normalize_DWI {
     """
     scil_compute_dti_metrics.py $dwi $bval $bvec --mask $mask\
         --not_all --fa fa.nii.gz
-    mrthreshold fa.nii.gz ${sid}_fa_wm_mask.nii.gz -abs $params.fa_threshold
+    mrthreshold fa.nii.gz ${sid}_fa_wm_mask.nii.gz -abs $params.fa_mask_threshold
     dwinormalise $dwi ${sid}_fa_wm_mask.nii.gz ${sid}__dwi_normalized.nii.gz\
         -fslgrad $bvec $bval
     """

--- a/main.nf
+++ b/main.nf
@@ -634,7 +634,10 @@ process Normalize_DWI {
 
     script:
     """
-    scil_compute_dti_metrics.py $dwi $bval $bvec --mask $mask\
+    scil_extract_dwi_shell.py $dwi \
+        $bval $bvec $params.dti_shells dwi_dti.nii.gz \
+        bval_dti bvec_dti -t $params.dwi_shell_tolerance
+    scil_compute_dti_metrics.py dwi_dti.nii.gz bval_dti bvec_dti --mask $mask\
         --not_all --fa fa.nii.gz
     mrthreshold fa.nii.gz ${sid}_fa_wm_mask.nii.gz -abs $params.fa_mask_threshold
     dwinormalise $dwi ${sid}_fa_wm_mask.nii.gz ${sid}__dwi_normalized.nii.gz\

--- a/main.nf
+++ b/main.nf
@@ -629,10 +629,15 @@ process Normalize_DWI {
 
     output:
     set sid, "${sid}__dwi_normalized.nii.gz" into dwi_for_resample
+    file "${sid}_fa_wm_mask.nii.gz"
 
     script:
     """
-    dwinormalise $dwi $mask ${sid}__dwi_normalized.nii.gz -fslgrad $bvec $bval
+    scil_compute_dti_metrics.py $dwi $bval $bvec --mask $mask\
+        --not_all --fa fa.nii.gz
+    mrthreshold fa.nii.gz ${sid}_fa_wm_mask.nii.gz -abs $params.fa_threshold
+    dwinormalise $dwi ${sid}_fa_wm_mask.nii.gz ${sid}__dwi_normalized.nii.gz\
+        -fslgrad $bvec $bval
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,6 +44,9 @@ params {
         t1_resolution=1
         t1_interpolation="lin"
 
+    //**Normalize DWI**//
+        fa_threshold=0.4
+
     //**Resample DWI**//
         run_resample_dwi=true
         dwi_resolution=1

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
         t1_interpolation="lin"
 
     //**Normalize DWI**//
-        fa_threshold=0.4
+        fa_mask_threshold=0.4
 
     //**Resample DWI**//
         run_resample_dwi=true


### PR DESCRIPTION
Compute a WM mask from an FA for normalization.

Default FA threshold is 0.4.