### PR TITLE
Add option to compute dwi sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Diffusion processes
 - crop DWI (Scilpy)
 - upsample DWI (Scilpy)
 - upsample B0 (Scilpy)
+- extract SH fitted to DWI (Scilpy)
 
 T1 processes
 - denoise T1 (Scilpy)

--- a/USAGE
+++ b/USAGE
@@ -57,7 +57,11 @@ OPTIONAL BIDS ARGUMENTS (current value)
 
 OPTIONAL ARGUMENTS (current value)
 
---compute_sh                                Compute DWI ODF as SH using the provided --basis and --sh_order ($compute_sh).
+--sh_fitting                                Compute a Spherical Harmonics fitting onto the DWI, and output the SH coefficients in a Nifti file ($compute_sh).
+--sh_fitting_basis                          SH basis used for the optional SH fitting [descoteaux07, tournier07] ($sh_fitting_basis).
+--sh_fitting_order                          SH order used for the optional SH fitting; must be an even number ($sh_fitting_order).
+                                            Rules :-sh_order=8 for 45 directions
+                                                   -sh_order=6 for 28 directions
 
 --b0_thr_extract_b0                         All b-values below b0_thr_extract_b0 are considered b=0 images ($b0_thr_extract_b0).
 --dwi_shell_tolerance                       All b-values to +-dwi_shell_tolerance are considered as the same b-value ($dwi_shell_tolerance).

--- a/USAGE
+++ b/USAGE
@@ -119,8 +119,10 @@ OPTIONAL ARGUMENTS (current value)
 --sh_fitting_order                          SH order used for the optional SH fitting; must be an even number ($sh_fitting_order).
                                             Rules :-sh_order=8 for 45 directions
                                                    -sh_order=6 for 28 directions
---sh_fitting_shell                          Shell selected to compute the SH fitting ($sh_fitting_shell).
+--sh_fitting_shell                          Shell selected to compute the SH fitting.
+                                            Please write them between quotes e.g. (--sh_fitting_shell "0 1000").
                                             NOTE: SH fitting works only on single shell.
+
 
 --run_pft_tracking                          Run Particle Filter Tracking (PFT) ($run_pft_tracking).
 

--- a/USAGE
+++ b/USAGE
@@ -121,7 +121,7 @@ OPTIONAL ARGUMENTS (current value)
                                                    -sh_order=6 for 28 directions
 --sh_fitting_shells                         Shells selected to compute the SH fitting.
                                             Please write them between quotes e.g. (--sh_fitting_shells "0 1000").
-                                            NOTE: SH fitting works only on single shell.
+                                            NOTE: SH fitting works only on single shell. You must include the b0 shell as well.
 
 
 --run_pft_tracking                          Run Particle Filter Tracking (PFT) ($run_pft_tracking).

--- a/USAGE
+++ b/USAGE
@@ -119,8 +119,8 @@ OPTIONAL ARGUMENTS (current value)
 --sh_fitting_order                          SH order used for the optional SH fitting; must be an even number ($sh_fitting_order).
                                             Rules :-sh_order=8 for 45 directions
                                                    -sh_order=6 for 28 directions
---sh_fitting_shell                          Shell selected to compute the SH fitting.
-                                            Please write them between quotes e.g. (--sh_fitting_shell "0 1000").
+--sh_fitting_shells                         Shells selected to compute the SH fitting.
+                                            Please write them between quotes e.g. (--sh_fitting_shells "0 1000").
                                             NOTE: SH fitting works only on single shell.
 
 

--- a/USAGE
+++ b/USAGE
@@ -62,6 +62,8 @@ OPTIONAL ARGUMENTS (current value)
 --sh_fitting_order                          SH order used for the optional SH fitting; must be an even number ($sh_fitting_order).
                                             Rules :-sh_order=8 for 45 directions
                                                    -sh_order=6 for 28 directions
+--sh_fitting_shell                          Shell selected to compute the SH fitting ($sh_fitting_shell).
+                                            NOTE: SH fitting works only on single shell.
 
 --b0_thr_extract_b0                         All b-values below b0_thr_extract_b0 are considered b=0 images ($b0_thr_extract_b0).
 --dwi_shell_tolerance                       All b-values to +-dwi_shell_tolerance are considered as the same b-value ($dwi_shell_tolerance).

--- a/USAGE
+++ b/USAGE
@@ -57,14 +57,6 @@ OPTIONAL BIDS ARGUMENTS (current value)
 
 OPTIONAL ARGUMENTS (current value)
 
---sh_fitting                                Compute a Spherical Harmonics fitting onto the DWI, and output the SH coefficients in a Nifti file ($compute_sh).
---sh_fitting_basis                          SH basis used for the optional SH fitting [descoteaux07, tournier07] ($sh_fitting_basis).
---sh_fitting_order                          SH order used for the optional SH fitting; must be an even number ($sh_fitting_order).
-                                            Rules :-sh_order=8 for 45 directions
-                                                   -sh_order=6 for 28 directions
---sh_fitting_shell                          Shell selected to compute the SH fitting ($sh_fitting_shell).
-                                            NOTE: SH fitting works only on single shell.
-
 --b0_thr_extract_b0                         All b-values below b0_thr_extract_b0 are considered b=0 images ($b0_thr_extract_b0).
 --dwi_shell_tolerance                       All b-values to +-dwi_shell_tolerance are considered as the same b-value ($dwi_shell_tolerance).
 
@@ -120,6 +112,15 @@ OPTIONAL ARGUMENTS (current value)
 --relative_threshold                        Relative threshold on fODF amplitude in ]0,1] ($relative_threshold).
 --max_fa_in_ventricle                       Maximal threshold of FA to be considered as ventricule voxel ($max_fa_in_ventricle).
 --min_md_in_ventricle                       Minimal threshold of MD in mm2/s to be considered as ventricule voxel ($min_md_in_ventricle).
+
+
+--sh_fitting                                Compute a Spherical Harmonics fitting onto the DWI, and output the SH coefficients in a Nifti file ($sh_fitting).
+--sh_fitting_basis                          SH basis used for the optional SH fitting [descoteaux07, tournier07] ($sh_fitting_basis).
+--sh_fitting_order                          SH order used for the optional SH fitting; must be an even number ($sh_fitting_order).
+                                            Rules :-sh_order=8 for 45 directions
+                                                   -sh_order=6 for 28 directions
+--sh_fitting_shell                          Shell selected to compute the SH fitting ($sh_fitting_shell).
+                                            NOTE: SH fitting works only on single shell.
 
 --run_pft_tracking                          Run Particle Filter Tracking (PFT) ($run_pft_tracking).
 

--- a/USAGE
+++ b/USAGE
@@ -57,6 +57,8 @@ OPTIONAL BIDS ARGUMENTS (current value)
 
 OPTIONAL ARGUMENTS (current value)
 
+--compute_sh                                Compute DWI ODF as SH using the provided --basis and --sh_order ($compute_sh).
+
 --b0_thr_extract_b0                         All b-values below b0_thr_extract_b0 are considered b=0 images ($b0_thr_extract_b0).
 --dwi_shell_tolerance                       All b-values to +-dwi_shell_tolerance are considered as the same b-value ($dwi_shell_tolerance).
 

--- a/main.nf
+++ b/main.nf
@@ -231,7 +231,7 @@ if (!params.dti_shells || !params.fodf_shells){
     error "Error ~ Please set the DTI and fODF shells to use."
 }
 
-if (params.sh_fitting && !params.sh_fitting_shell){
+if (params.sh_fitting && !params.sh_fitting_shells){
     error "Error ~ Please set the SH fitting shell to use."
 }
 
@@ -918,7 +918,7 @@ process Extract_SH_Fitting_Shell {
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
     scil_extract_dwi_shell.py $dwi \
-        $bval $bvec $params.sh_fitting_shell ${sid}__dwi_sh_fitting.nii.gz \
+        $bval $bvec $params.sh_fitting_shells ${sid}__dwi_sh_fitting.nii.gz \
         ${sid}__bval_sh_fitting ${sid}__bvec_sh_fitting -t $params.dwi_shell_tolerance -f
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -915,7 +915,7 @@ process Extract_SH_Fitting_Shell {
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
     scil_extract_dwi_shell.py $dwi \
-        $bval $bvec 0 $params.sh_fitting_shell ${sid}__dwi_sh_fittting.nii.gz \
+        $bval $bvec 0 $params.sh_fitting_shell ${sid}__dwi_sh_fitting.nii.gz \
         ${sid}__bval_sh_fitting ${sid}__bvec_sh_fitting -t $params.dwi_shell_tolerance -f
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -17,7 +17,6 @@ if(params.help) {
                 "sh_fitting":"$params.sh_fitting",
                 "sh_fitting_basis":"$params.sh_fitting_basis",
                 "sh_fitting_order":"$params.sh_fitting_order",
-                "sh_fitting_shell":"$params.sh_fitting_shell",
                 "b0_thr_extract_b0":"$params.b0_thr_extract_b0",
                 "dwi_shell_tolerance":"$params.dwi_shell_tolerance",
                 "dilate_b0_mask_prelim_brain_extraction":"$params.dilate_b0_mask_prelim_brain_extraction",
@@ -230,6 +229,10 @@ else {
 
 if (!params.dti_shells || !params.fodf_shells){
     error "Error ~ Please set the DTI and fODF shells to use."
+}
+
+if (params.sh_fitting && !params.sh_fitting_shell){
+    error "Error ~ Please set the SH fitting shell to use."
 }
 
 if (params.pft_seeding_mask_type != "wm" && params.pft_seeding_mask_type != "interface" && params.pft_seeding_mask_type != "fa"){
@@ -915,7 +918,7 @@ process Extract_SH_Fitting_Shell {
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
     scil_extract_dwi_shell.py $dwi \
-        $bval $bvec 0 $params.sh_fitting_shell ${sid}__dwi_sh_fitting.nii.gz \
+        $bval $bvec $params.sh_fitting_shell ${sid}__dwi_sh_fitting.nii.gz \
         ${sid}__bval_sh_fitting ${sid}__bvec_sh_fitting -t $params.dwi_shell_tolerance -f
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -14,7 +14,9 @@ if(params.help) {
 
     cpu_count = Runtime.runtime.availableProcessors()
     bindings = ["clean_bids":"$params.clean_bids",
-                "compute_sh":"$params.compute_sh",
+                "sh_fitting":"$params.sh_fitting",
+                "sh_fitting_basis":"$params.sh_fitting_basis",
+                "sh_fitting_order":"$params.sh_fitting_order",
                 "b0_thr_extract_b0":"$params.b0_thr_extract_b0",
                 "dwi_shell_tolerance":"$params.dwi_shell_tolerance",
                 "dilate_b0_mask_prelim_brain_extraction":"$params.dilate_b0_mask_prelim_brain_extraction",
@@ -341,7 +343,7 @@ process README {
     """
 }
 
-process DWI_SH {
+process SH_Fitting {
     cpus 1
 
     input:
@@ -351,14 +353,14 @@ process DWI_SH {
     file "${sid}__dwi_sh.nii.gz"
 
     when:
-    params.compute_sh
+    params.sh_fitting
 
     script:
     """
     export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
-    scil_compute_sh_from_signal.py --sh_order $params.sh_order --sh_basis $params.basis $dwi $bval $bvec ${sid}__dwi_sh.nii.gz
+    scil_compute_sh_from_signal.py --sh_order $params.sh_fitting_order --sh_basis $params.sh_fitting_basis $dwi $bval $bvec ${sid}__dwi_sh.nii.gz
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
         sh_fitting=false
         sh_fitting_order=6
         sh_fitting_basis="descoteaux07"
+        sh_fitting_shell=1000
 
 
     //**Preliminary DWI brain extraction**//

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,9 @@ params {
         b0_thr_extract_b0=10
         dwi_shell_tolerance=20
 
+    //**Compute DWI ODF as SH**//
+        compute_sh=false
+
     //**Preliminary DWI brain extraction**//
         dilate_b0_mask_prelim_brain_extraction=5
         bet_prelim_f=0.16

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,6 @@ params {
         sh_fitting=false
         sh_fitting_order=6
         sh_fitting_basis="descoteaux07"
-        sh_fitting_shell=1000
 
 
     //**Preliminary DWI brain extraction**//

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,8 +20,11 @@ params {
         b0_thr_extract_b0=10
         dwi_shell_tolerance=20
 
-    //**Compute DWI ODF as SH**//
-        compute_sh=false
+    //**SH fitting**//
+        sh_fitting=false
+        sh_fitting_order=6
+        sh_fitting_basis="descoteaux07"
+
 
     //**Preliminary DWI brain extraction**//
         dilate_b0_mask_prelim_brain_extraction=5


### PR DESCRIPTION
Optional --compute_sh option, useful to compute metrics from the signal ODF in the future.
Question:
- Should we have separate parameters for --basis and --sh_order, or do we keep using the same ones we use for the fODF?