### PR TITLE
RF - skip bet_prelim_dwi if run_eddy is false

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -387,7 +387,7 @@ process Bet_Prelim_DWI {
     file "${sid}__b0_bet_mask.nii.gz"
 
     when:
-    rev_b0_count == 0 || (!params.run_topup && params.run_eddy)
+    params.run_eddy
 
     script:
     """


### PR DESCRIPTION
`Bet_prelim_dwi` process is run, even when `run_eddy=false` if `rev_b0_count==0`. This fixes this.

This process outputs the brain mask for eddy and is not needed if Eddy is not run. All topup and eddy processes require `run_eddy=true` to be run. 