### PR TITLE
Fix bc not supporting python scientific notation

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1636,7 +1636,7 @@ process FODF_Metrics {
         --fa_t $params.max_fa_in_ventricle --md_t $params.min_md_in_ventricle\
         -f
 
-    v_max=\$(sed -E 's/([+-]?[0-9.]+)[eE]\+?(-?)([0-9]+)/(\1*10^\2\3)/g' <<<"\$(cat ventricles_fodf_max_value.txt)")
+    v_max=\$(sed -E 's/([+-]?[0-9.]+)[eE]\\+?(-?)([0-9]+)/(\\1*10^\\2\\3)/g' <<<"\$(cat ventricles_fodf_max_value.txt)")
     a_threshold=\$(echo "scale=10 $params.fodf_metrics_a_factor*\$v_max" | bc)
 
     scil_compute_fodf_metrics.py ${sid}__fodf.nii.gz\

--- a/main.nf
+++ b/main.nf
@@ -1638,6 +1638,7 @@ process FODF_Metrics {
 
     v_max=\$(sed -E 's/([+-]?[0-9.]+)[eE]\\+?(-?)([0-9]+)/(\\1*10^\\2\\3)/g' <<<"\$(cat ventricles_fodf_max_value.txt)")
     a_threshold=\$(echo "scale=10 $params.fodf_metrics_a_factor*\$v_max" | bc)
+    a_threshold=\$(( a_threshold > 0 ? a_threshold : 0 ))
 
     scil_compute_fodf_metrics.py ${sid}__fodf.nii.gz\
         --mask $b0_mask --sh_basis $params.basis\

--- a/main.nf
+++ b/main.nf
@@ -1636,7 +1636,8 @@ process FODF_Metrics {
         --fa_t $params.max_fa_in_ventricle --md_t $params.min_md_in_ventricle\
         -f
 
-    a_threshold=\$(echo $params.fodf_metrics_a_factor*\$(cat ventricles_fodf_max_value.txt)|bc)
+    v_max=\$(sed -E 's/([+-]?[0-9.]+)[eE]\+?(-?)([0-9]+)/(\1*10^\2\3)/g' <<<"\$(cat ventricles_fodf_max_value.txt)")
+    a_threshold=\$(echo "scale=10 $params.fodf_metrics_a_factor*\$v_max" | bc)
 
     scil_compute_fodf_metrics.py ${sid}__fodf.nii.gz\
         --mask $b0_mask --sh_basis $params.basis\

--- a/main.nf
+++ b/main.nf
@@ -1637,8 +1637,10 @@ process FODF_Metrics {
         -f
 
     v_max=\$(sed -E 's/([+-]?[0-9.]+)[eE]\\+?(-?)([0-9]+)/(\\1*10^\\2\\3)/g' <<<"\$(cat ventricles_fodf_max_value.txt)")
-    a_threshold=\$(echo "scale=10 $params.fodf_metrics_a_factor*\$v_max" | bc)
-    a_threshold=\$(( a_threshold > 0 ? a_threshold : 0 ))
+    a_threshold=\$(echo "scale=10; $params.fodf_metrics_a_factor*\$v_max" | bc)
+    if (( $(echo "\$a_threshold < 0" | bc -l) )); then
+        a_threshold=0
+    fi
 
     scil_compute_fodf_metrics.py ${sid}__fodf.nii.gz\
         --mask $b0_mask --sh_basis $params.basis\

--- a/main.nf
+++ b/main.nf
@@ -1638,7 +1638,7 @@ process FODF_Metrics {
 
     v_max=\$(sed -E 's/([+-]?[0-9.]+)[eE]\\+?(-?)([0-9]+)/(\\1*10^\\2\\3)/g' <<<"\$(cat ventricles_fodf_max_value.txt)")
     a_threshold=\$(echo "scale=10; $params.fodf_metrics_a_factor*\$v_max" | bc)
-    if (( $(echo "\$a_threshold < 0" | bc -l) )); then
+    if (( \$(echo "\$a_threshold < 0" | bc -l) )); then
         a_threshold=0
     fi
 


### PR DESCRIPTION
Regex replace python scientific notation (e^) to bc notation (10^)
Set bc to 10 decimals precision
